### PR TITLE
fix toggle +/-, add hide deletion button, code refactor

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -4,17 +4,22 @@
   var INJECT_BUTTON_TRY_INTERVAL = 500;
   var injectCounter = 0;
 
-  (function injectButton() {
+  function injectButtons() {
     setTimeout(function() {
       var $commitFiles = $('.actions .show-file-notes');
+
+      if ($('.minibutton.hide-add-content').length) {
+        return;
+      }
+
       if (!$commitFiles.length && injectCounter <= INJECT_BUTTON_TRY_TIMES) {
         injectCounter++;
-        injectButton();
+        injectButtons();
       } else {
         $commitFiles.after('<button class="minibutton hide-add-content">Toggle +/-</button><button class="minibutton collapsable">Hide Diff</button><button class="minibutton hide-deletion">Hide Deletion</button>');
       }
     }, INJECT_BUTTON_TRY_INTERVAL);
-  })();
+  }
 
   function toggleCollapse() {
     var $button      = $(this);
@@ -89,5 +94,15 @@
   .on('click', '.minibutton.collapsable', toggleCollapse)
   .on('click', '.minibutton.hide-add-content', toggleAddDeleteSymbol)
   .on('click', '.minibutton.hide-deletion', toggleDeletion);
+
+  // inject buttons on file change tab button click
+  $('body').on('click', '[data-container-id="files_bucket"]', function() {
+    injectButtons();
+  });
+
+  // inject buttons on page load
+  if ($('.actions .show-file-notes').length) {
+    injectButtons();
+  }
 
 })();


### PR DESCRIPTION
@MuscularMustache 
Did several changes here
##### fix toggle +/-

Trying to replace the html instead of text, this will keep the comment button. Also toggle the `-` symbol. 
##### add a Hide Deletion button

I feel like I am not comfortable to view add/deleted code mixing together. So I add this button to hide code deleted and hide the `+` to make copy easier. 
##### code refactoring
- buttons is put into a function that will keep running until success. The function is triggered by page load or "Files Chnaged" tab button click. This is because github is using client side rendering, so buttons were not always be injected unless we reload page. 
- event handlers are put into separate functions, to make code looks more meaningful
- file is wrap into a IIFE, to avoid global variable pollution.
